### PR TITLE
Fixed issue with RequiredFieldValidator

### DIFF
--- a/CMPG223_Group_13.csproj
+++ b/CMPG223_Group_13.csproj
@@ -133,6 +133,7 @@
     </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="System_Classes\Bank_Account_Info.cs" />
+    <Compile Include="System_Classes\DatabaseHandler.cs" />
     <Compile Include="System_Classes\User.cs" />
     <Compile Include="System_Classes\Farm.cs" />
     <Compile Include="System_Classes\Listed_Produce.cs" />

--- a/default.aspx
+++ b/default.aspx
@@ -14,7 +14,7 @@
                 <div>
                     Email: <asp:TextBox ID="tbEmail" runat="server"></asp:TextBox>   
                 </div>
-                <asp:RequiredFieldValidator ID="RequiredFieldValidator2" runat="server" ControlToValidate="tbUsername" ErrorMessage="Email required" ForeColor="#FF0066"></asp:RequiredFieldValidator>
+                <asp:RequiredFieldValidator ID="RequiredFieldValidator2" runat="server" ControlToValidate="tbEmail" ErrorMessage="Email required" ForeColor="#FF0066"></asp:RequiredFieldValidator>
                 <div>
                     Password: <asp:TextBox ID="tbPassword" runat="server"></asp:TextBox>  
                 </div>


### PR DESCRIPTION
One of the validators was still looking for tbUsername, even though it had been renamed to tbEmail